### PR TITLE
Enable bucket value attribution

### DIFF
--- a/templates/config.configmap.yaml
+++ b/templates/config.configmap.yaml
@@ -11,3 +11,4 @@ data:
     minio.access-key: {{ .Values.accessKey }} 
     minio.secret-key: {{ .Values.secretKey }}
     server.address: :7777
+    client.user-agent: MongoDB


### PR DESCRIPTION
I am not sure if this config change will do it. I do know that we need to specify a user agent in order to enable value attribution. The easiest way to find out would be if you could create a new bucket with this code change and I check the value attribution in the satellite DB.